### PR TITLE
Updated card test so that it passes.

### DIFF
--- a/test/spec/directives/card.js
+++ b/test/spec/directives/card.js
@@ -31,8 +31,11 @@ describe('Directive: unleashCard', function () {
   }));
 
   describe('card', function() {
-    it('should render its type', function() {
-      expect(element[0].querySelector('.card__type').innerHTML).to.equal(card.type);
+    it('should render its type and task', function() {
+      var cardType = element[0].querySelector('.card__type');
+
+      expect(cardType.innerHTML).to.contain(card.type);
+      expect(cardType.innerHTML).to.contain(card.task);
     });
 
     it('should render its level', function() {


### PR DESCRIPTION
Here's a fix to the test that has been failing recently.

The problem was caused by the fact, that the respective test wasn't updated after the card template was modified.