### PR TITLE
Fixed Dockerfile to have the image contain all sources and shorten the getting the container up process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ RUN gem install sass --version "=3.4.8"
 RUN gem install compass --version "=1.0.1"
 RUN npm install -g bower grunt-cli
 
-ADD . /var/www/unleash
-
 WORKDIR /var/www/unleash
+
+ADD . /var/www/unleash
+RUN npm install && bower install --allow-root
 
 CMD npm start

--- a/README.md
+++ b/README.md
@@ -31,12 +31,21 @@ Given `192.168.99.100` is your machines ip add a line like this to your `/etc/ho
 
 ## Setup
 
+### Install dependencies
+
+In order to install node & bower dependencies run the command (it might take a while but it's one-time only):
+```
+docker-compose run web npm install && bower install --allow-root
+```
+
+### Running
+
 In the Docker Quickstart Terminal go to the application folder and type:
 ```
 docker-compose up
 ```
 
-Wait for Docker to build and run the application.
+Wait for Docker to run the application.
 
 Once the application is running and the "watch" task is in a waiting state you can access it at [http://unleash.dev](http://unleash.dev).
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "./node_modules/protractor/bin/webdriver-manager update",
-    "prestart": "npm install && bower install --allow-root",
     "start": "grunt serve",
     "test": "grunt test"
   }


### PR DESCRIPTION
This will make the initial build on local a bit longer (and on Docker Hub) but will make it shorter and less memory consuming to run on a web server. 