### PR TITLE
Fix race condition when auth status switches to null. #46

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -51,7 +51,7 @@ angular.module('unleashApp', [
       }
 
       userService.getUserDetails().then(function(data) {
-        if (!data.username) {
+        if (!data.username || !$rootScope.user) {
           return;
         }
 


### PR DESCRIPTION
This pull request fixes #46.

Because the function `setUserData` in `scripts/app.js` has some async operations in it, whenever the auth status changes from logged in to `null` a race condition occurs and may cause this error.

Added a simple check in the promise. I guess this is the smallest change that is able to solve this problem.