### PR TITLE
Fix the appearance of app content

### DIFF
--- a/app/components/UnleashApp.js
+++ b/app/components/UnleashApp.js
@@ -14,10 +14,16 @@ const UnleashApp = (props) => (
   <MuiThemeProvider muiTheme={muiTheme}>
     <div>
       <Menu />
-      {props.children}
+      <div style={styles.wrapper}>{props.children}</div>
     </div>
   </MuiThemeProvider>
 );
+
+const styles = {
+  wrapper: {
+    padding: '0 0 0 250px',
+  },
+};
 
 UnleashApp.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
# Issue https://github.com/x-team/unleash/issues/210

`Drawer` from [`material-ui`](http://www.material-ui.com/#/components/drawer) is positioned `fixed`, so that the content of the app is hidden below it.

One of the solution (the same as they do at http://www.material-ui.com) is to increase the padding of the content wrapper in order to make it visible.

<img width="650" alt="screen shot 2016-08-13 at 08 39 41" src="https://cloud.githubusercontent.com/assets/6726839/17641888/3f81fbae-6132-11e6-9e8f-71f98c80fe05.png">
