### PR TITLE
Fix Docker filesystem issue with npm - fixes #238

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM node:6.3
+FROM node:6.5
 
 RUN npm install -g babel-cli webpack
+
+# Fix bug https://github.com/npm/npm/issues/9863
+RUN cd $(npm root -g)/npm \
+  && npm install fs-extra \
+  && sed -i -e s/graceful-fs/fs-extra/ -e s/fs\.rename/fs.move/ ./lib/utils/rename.js
 
 CMD npm start


### PR DESCRIPTION
This was a bug that occurred on a Docker Toolbox setup (with VM) and didn't on Docker For Mac. It's an issue mentioned here: https://github.com/npm/npm/issues/9863 and the workaround mentioned there a lot is used.