### PR TITLE
Fix Test Warnings - Fixes #240

### DIFF
--- a/app/components/Path.js
+++ b/app/components/Path.js
@@ -55,7 +55,7 @@ export class Paths extends Component {
 
 Paths.propTypes = {
   actions: React.PropTypes.object.isRequired,
-  paths: React.PropTypes.object.isRequired,
+  paths: React.PropTypes.array.isRequired,
   location: React.PropTypes.object.isRequired,
   profiles: React.PropTypes.object.isRequired,
 };

--- a/app/components/__tests__/Menu.spec.js
+++ b/app/components/__tests__/Menu.spec.js
@@ -5,6 +5,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import Menu from '../Menu';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+
+// As we're testing a component that use 'onTouchTap', we
+// need to inject the Tap Event Plugin.
+injectTapEventPlugin();
 
 describe('Menu Component', () => {
   let component;

--- a/app/reducers/pathsReducer.js
+++ b/app/reducers/pathsReducer.js
@@ -6,7 +6,7 @@
 
 import { PATHS_LIST_SUCCESS, PATHS_LIST_FAILURE } from '../actions/PathsActions';
 
-function pathsReducer(paths = {}, action) {
+function pathsReducer(paths = [], action) {
   Object.freeze(paths);
 
   let newPaths;
@@ -21,7 +21,7 @@ function pathsReducer(paths = {}, action) {
       });
       return newPaths;
     case PATHS_LIST_FAILURE:
-      return {};
+      return [];
     default:
       return paths;
   }


### PR DESCRIPTION
- Add 'react-tap-event-plugin' on Menu tests because Menu component use 'onTouchTap' event
- Fix Paths Reducer since it was initializing 'paths' state property with an Object instead of an Array, leading to a PropType error message.

![image](https://cloud.githubusercontent.com/assets/1239143/18391511/8e52118a-7684-11e6-97e8-f89e1c70a6ad.png)
