### PR TITLE
Refactor actions reducers #245

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Unleash your path
+# Unleash your potential
 
-A project dedicated to help X-Teamers grow and see a progress they make along the way.
+An app that helps developers grow and track their progress.
 
 [![Build Status](https://travis-ci.org/x-team/unleash.svg?branch=master)](https://travis-ci.org/x-team/unleash)
 [![dependencies Status](https://david-dm.org/x-team/unleash/status.svg)](https://david-dm.org/x-team/unleash)
@@ -8,7 +8,7 @@ A project dedicated to help X-Teamers grow and see a progress they make along th
 
 ## Requirements
 
-Basically, you need to install:
+You need to install:
 - [Docker](https://www.docker.com)
 
 (Note: if you're using OS X and install Docker Toolbox with Docker Machine webpack's liverload won't probably work - please install Docker For Mac to fully utilize webpack's livereloading)

--- a/app/actions/PathsActions.js
+++ b/app/actions/PathsActions.js
@@ -5,22 +5,11 @@
  */
 
 import config from '../../config';
+import { createAction } from 'redux-act';
 
-export const PATHS_LIST = 'PATHS_LIST';
-export const PATHS_LIST_SUCCESS = 'PATHS_LIST_SUCCESS';
-export const PATHS_LIST_FAILURE = 'PATHS_LIST_FAILURE';
-
-function doPathsList() {
-  return { type: PATHS_LIST };
-}
-
-export function pathsListSuccess(paths) {
-  return { type: PATHS_LIST_SUCCESS, paths };
-}
-
-export function pathsListFailure(errors) {
-  return { type: PATHS_LIST_FAILURE, errors };
-}
+export const doPathsList = createAction('PATHS_LIST');
+export const pathsListSuccess = createAction('PATHS_LIST_SUCCESS', (paths) => ({ paths }));
+export const pathsListFailure = createAction('PATHS_LIST_FAILURE', (errors) => ({ errors }));
 
 export function pathsList(userId) {
   return (dispatch) => {

--- a/app/actions/__tests__/PathsActions.spec.js
+++ b/app/actions/__tests__/PathsActions.spec.js
@@ -13,20 +13,12 @@ describe('Path Actions', () => {
 
   it('should create an action for pathsListSuccess', () => {
     const paths = '/unleash/paths';
-    const expectedAction = {
-      type: PathsActions.PATHS_LIST_SUCCESS,
-      paths
-    };
-    expect(PathsActions.pathsListSuccess(paths)).to.deep.equal(expectedAction);
+    expect(PathsActions.pathsListSuccess(paths)).to.deep.equal(PathsActions.pathsListSuccess.raw(paths));
   });
 
   it('should create an action for pathsListFailure', () => {
     const errors = 'Oops an error!';
-    const expectedAction = {
-      type: PathsActions.PATHS_LIST_FAILURE,
-      errors
-    };
-    expect(PathsActions.pathsListFailure(errors)).to.deep.equal(expectedAction);
+    expect(PathsActions.pathsListFailure(errors)).to.deep.equal(PathsActions.pathsListFailure.raw(errors));
   });
 
   describe('Dispatch Actions', () => {
@@ -48,7 +40,7 @@ describe('Path Actions', () => {
       const requestCall = nock(hostname).get(path).reply(200, httpResponse);
 
       const expectedActions = [
-        {type: 'PATHS_LIST'},
+        PathsActions.doPathsList.raw(),
         PathsActions.pathsListSuccess(httpResponse)
       ];
 

--- a/app/reducers/pathsReducer.js
+++ b/app/reducers/pathsReducer.js
@@ -4,27 +4,10 @@
  * @author Kelvin De Moya <kelvin.demoya@x-team.com>
  */
 
-import { PATHS_LIST_SUCCESS, PATHS_LIST_FAILURE } from '../actions/PathsActions';
+import { createReducer } from 'redux-act';
+import { pathsListSuccess, pathsListFailure } from '../actions/PathsActions';
 
-function pathsReducer(paths = [], action) {
-  Object.freeze(paths);
-
-  let newPaths;
-
-  switch (action.type) {
-    case PATHS_LIST_SUCCESS:
-      newPaths = [];
-      action.paths.forEach((path) => {
-        if (path.goals.length) {
-          newPaths.push(path);
-        }
-      });
-      return newPaths;
-    case PATHS_LIST_FAILURE:
-      return [];
-    default:
-      return paths;
-  }
-}
-
-export default pathsReducer;
+export default createReducer({
+  [pathsListSuccess]: (state, payload) => payload.paths.filter((path) => path.goals.length),
+  [pathsListFailure]: () => []
+}, []);

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -1,8 +1,13 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
 import rootReducer from '../reducers/rootReducer';
 
-const middleware = [thunk];
+const logger = createLogger({
+  predicate: () => process.env.NODE_ENV !== 'production'
+});
+
+const middleware = [thunk, logger];
 let applyMiddlewareConfig = applyMiddleware(...middleware);
 
 if (process.env.NODE_ENV !== 'production') {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "react-router": "^2.6.0",
     "react-tap-event-plugin": "^1.0.0",
     "redux": "^3.5.2",
+    "redux-act": "^1.0.0",
+    "redux-logger": "^2.6.1",
     "redux-thunk": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a proposal for updating Action creators / Reducers to use `redux-act`.
I just updated one pair of Action / Reducer to give you an idea about it.

- Added `redux-act` on `PathsActions.js` and `pathsReducer.js`
- Updated Paths tests to reflect these changes

It drastically reduce the amount of boilerplate while creating action creators.
Also, it avoids typing / changing those `type` constants manually, and eventually, getting it wrong.

What you think about it?