### PR TITLE
Fix webpack plugin order.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new ConfigPlugin(['./config.js', './config.dist.js'])
+    new ConfigPlugin(['./config.dist.js', './config.js'])
   ]
 };


### PR DESCRIPTION
Before it override the `config.js` for `config.dist.js`.
Now it override the `config.dist.js` for `config.js`.