### PR TITLE
Fix broken icons introduced with react-toastr

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>X-Team Unleash</title>
   <link href='https://fonts.googleapis.com/css?family=Inconsolata|Roboto:400,300,500' rel='stylesheet' type='text/css'>
-  <link href="http://diegoddox.github.io/react-redux-toastr/3.0.1/react-redux-toastr.min.css" rel="stylesheet" type="text/css">
+  <link href="http://diegoddox.github.io/react-redux-toastr/3.8/react-redux-toastr.min.css" rel="stylesheet" type="text/css">
   <script src="https://www.gstatic.com/firebasejs/3.3.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/3.3.0/firebase-auth.js"></script>
 </head>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
     "react-redux": "^4.4.5",
-    "react-redux-toastr": "^3.7.0",
+    "react-redux-toastr": "^3.8.4",
     "react-router": "^2.6.0",
     "react-tap-event-plugin": "^1.0.0",
     "redux": "^3.5.2",


### PR DESCRIPTION
Icons got broken with the addition of react-redux-toastr, this is a known issue and will hopefully be fixed soon, need to keep an eye on this ticket (https://github.com/diegoddox/react-redux-toastr/issues/46)

Before:
<img width="1280" alt="screen shot 2016-09-24 at 8 53 34 pm" src="https://cloud.githubusercontent.com/assets/2904943/18812187/9c29be0e-8299-11e6-9b85-7a98c58985b7.png">
After:
<img width="1280" alt="screen shot 2016-09-24 at 8 53 50 pm" src="https://cloud.githubusercontent.com/assets/2904943/18812189/a3cf8b02-8299-11e6-8995-931357d9cebf.png">
