### PR TITLE
Run tests and linter before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   "bugs": {
     "url": "https://github.com/x-team/unleash/issues"
   },
+  "prepush": {
+    "run": ["test", "test:lint"],
+    "silent": true
+  },
   "nyc": {
     "exclude": [
       "**/*.spec.js",
@@ -77,6 +81,7 @@
     "mocha": "^2.5.3",
     "nock": "^8.0.0",
     "nyc": "^8.1.0",
+    "pre-push": "^0.1.1",
     "react-addons-test-utils": "^15.2.1",
     "redux-mock-store": "^1.1.4",
     "sinon": "^1.17.5",


### PR DESCRIPTION
A common thing I've seen in several PRs (including mines) is that sometimes they fail because of broken tests or linters, then we have to fix them and push the branch again. 

Both will be now executed and will prevent the push of a branch if one of them fails. This way we won't open the PRs just to find out later that the build failed.