### PR TITLE
Add Webpack HMR, fixes #221

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", "es2015", "stage-0"],
   "env": {
     "development": {
       "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,19 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["react", "es2015"],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }, {
+            "transform": "react-transform-catch-errors",
+            "imports": ["react", "redbox-react"]
+          }]
+        }]
+      ]
+    }
+  }
 }

--- a/devServer.js
+++ b/devServer.js
@@ -1,17 +1,23 @@
 import path from 'path';
 import webpack from 'webpack';
-import webpackDevMiddleware from 'webpack-dev-middleware';
-import config from './webpack.config';
-import Express from 'express';
+import express from 'express';
 
-const app = new Express();
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpackHotMiddleware from 'webpack-hot-middleware';
+
+import config from './webpack.config';
+
+const app = express();
 const port = 3000;
 
 const compiler = webpack(config);
+
 app.use(webpackDevMiddleware(compiler, {
   noInfo: true,
   publicPath: config.output.publicPath,
 }));
+
+app.use(webpackHotMiddleware(compiler));
 
 app.get('/*', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
@@ -23,8 +29,7 @@ app.listen(port, error => {
     console.error(error);
   } else {
     console.info(
-      '🌎 Listening on port %s. Open up http://localhost:%s/ in your browser.',
-      port,
+      '🌎 Listening on port %s (Docker). Open up http://localhost in your browser.',
       port
     );
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,3 @@ web:
   working_dir: /var/www/unleash
   ports:
     - 80:3000
-webpack:
-  build: .
-  volumes_from:
-    - web
-  working_dir: /var/www/unleash
-  command: webpack -w

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "babel-node devServer.js",
-    "test": "mocha --require app/testUtils/setup.js --recursive app/**/*.spec.js",
-    "test:tdd": "mocha -w --require app/testUtils/setup.js --recursive app/**/*.spec.js",
-    "test:lint": "eslint ./app",
-    "coverage": "nyc mocha --require app/testUtils/setup.js --recursive app/**/*.spec.js"
+    "test": "cross-env NODE_ENV=test mocha --require app/testUtils/setup.js --recursive app/**/*.spec.js",
+    "test:tdd": "cross-env NODE_ENV=test mocha -w --require app/testUtils/setup.js --recursive app/**/*.spec.js",
+    "test:lint": "cross-env NODE_ENV=test eslint ./app",
+    "coverage": "cross-env NODE_ENV=test nyc mocha --require app/testUtils/setup.js --recursive app/**/*.spec.js"
   },
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/x-team/unleash#readme",
   "dependencies": {
+    "cross-env": "^3.1.3",
     "immutable": "^3.8.1",
     "lodash": "^4.15.0",
     "material-ui": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-core": "^6.10.4",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-react-transform": "^2.0.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
@@ -87,11 +88,15 @@
     "nyc": "^8.1.0",
     "pre-push": "^0.1.1",
     "react-addons-test-utils": "^15.2.1",
+    "react-transform-catch-errors": "^1.0.2",
+    "react-transform-hmr": "^1.0.4",
+    "redbox-react": "^1.3.2",
     "redux-mock-store": "^1.1.4",
     "sinon": "^1.17.5",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
-    "webpack-dev-middleware": "^1.6.1"
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-hot-middleware": "^2.13.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,17 @@
 const path = require('path');
+const webpack = require('webpack');
+
 const ConfigPlugin = require('config-webpack-plugin');
 
 module.exports = {
-  entry: './app/App.js',
+  entry: [
+    // Add the client which connects to our middleware
+    // You can use full urls like 'webpack-hot-middleware/client?path=http://localhost:3000/__webpack_hmr'
+    // useful if you run your app from another point like django
+    'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000',
+    // And then the actual application
+    './app/App.js'
+  ],
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
@@ -22,24 +31,31 @@ module.exports = {
         exclude: /(node_modules|bower_components)/,
         loader: 'babel',
         query: {
-          presets: ['es2015', 'stage-0', 'react']
+          presets: ['es2015', 'stage-0', 'react'],
+          // cacheDirectory: './node_modules/.cache/babel-loader'
         }
       },
       {
         test: /\.(png|jpg|)$/,
         loader: 'url-loader?limit=200000'
       },
-      { test: /\.css$/, loader: "style-loader!css-loader" },
+      { test: /\.css$/, loader: 'style-loader!css-loader' },
       {
         test: /\.woff(2)?(\?[a-z0-9]+)?$/,
-        loader: "url-loader?limit=10000&mimetype=application/font-woff"
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff'
       }, {
         test: /\.(ttf|eot|svg)(\?[a-z0-9]+)?$/,
-        loader: "file-loader"
+        loader: 'file-loader'
       }
     ]
   },
   plugins: [
-    new ConfigPlugin(['./config.js', './config.local.js'])
+    new ConfigPlugin(['./config.js', './config.local.js']),
+    // Webpack 1.0
+    new webpack.optimize.OccurenceOrderPlugin(),
+    // Webpack 2.0 fixed this mispelling
+    // new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
   ]
 };


### PR DESCRIPTION
# HMR with Webpack

## Dev server

This would be easily done with [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html)'s CLI but the local dev environment is ran with
`   
"start": "babel-node devServer.js"
`
that looks like a custom dev server.
To keep compatibility and customizability I left the current configuration untouched but I added a new middleware: `webpack-hot-middleware`.
This triggers Webpack's Hot Module Replacement, but it then needs instructions on how to apply the `hot` changes.

## Babel transform

I then added `babel-plugin-react-transform` with `react-transform-hmr` although the project is being deprecated/rewritten (the new version is not stable yet...).
This instructs Webpack on how to apply `hot` changes.

## Alternative solutions
There's a new trend of "zero-config" applications, led by [create-react-app](https://github.com/facebookincubator/create-react-app) but with also a lot of [alternatives](https://github.com/facebookincubator/create-react-app#alternatives). 
My favourite setup is [nwb](https://github.com/insin/nwb) since it leaves space to customizations.

### Demo
![nov-08-2016 13-27-51](https://cloud.githubusercontent.com/assets/735227/20099831/d68188ae-a5ba-11e6-80a7-ebe77e4ce363.gif)
