### PR TITLE
Fallback for new Date() if date is null - fixes #359

### DIFF
--- a/app/components/AddGoalsModal.jsx
+++ b/app/components/AddGoalsModal.jsx
@@ -54,7 +54,7 @@ class AddGoalsModal extends React.Component {
         container="inline"
         mode="landscape"
         onChange={(event, date) => actions.updateAddGoalsField('dueDate', date)}
-        value={new Date(parameters.dueDate)}
+        value={parameters.dueDate ? new Date(parameters.dueDate) : null}
       />
     );
   }


### PR DESCRIPTION
Found a problem with @kdemoya's fix on #359 - we need to check if date is not null before creating `new Date()`