### PR TITLE
Reset resource dialog on adding resource - fixes #384

### DIFF
--- a/app/components/Skill.jsx
+++ b/app/components/Skill.jsx
@@ -38,7 +38,7 @@ class Skill extends Component {
   constructor(props) {
     super(props);
 
-    this.state = this.getInitDialogState();
+    this.state = this.getInitalDialogState();
   }
 
   componentDidMount() {
@@ -70,7 +70,7 @@ class Skill extends Component {
   })
   .sort((a, b) => b.upvotes - a.upvotes);
 
-  getInitDialogState() {
+  getInitalDialogState() {
     return {
       resource_url: '',
       resource_description: '',
@@ -131,7 +131,7 @@ class Skill extends Component {
         author_id: userId,
       });
       toggleOff(DIALOG_TOGGLE);
-      this.setState(this.getInitDialogState());
+      this.setState(this.getInitalDialogState());
     }
   }
 

--- a/app/components/Skill.jsx
+++ b/app/components/Skill.jsx
@@ -141,7 +141,14 @@ class Skill extends Component {
       <FlatButton
         label="Add Resource"
         primary
-        onTouchTap={() => this.addResource(skillSlug)}
+        onTouchTap={() => {
+          this.addResource(skillSlug);
+          this.setState({
+            resource_url: '',
+            resource_description: '',
+            resource_type: 'other',
+          });
+        }}
       />,
     ];
 

--- a/app/components/Skill.jsx
+++ b/app/components/Skill.jsx
@@ -36,7 +36,7 @@ class Skill extends Component {
   constructor(props) {
     super(props);
 
-    this.initDialogState();
+    this.state = this.getInitDialogState();
   }
 
   componentDidMount() {
@@ -67,8 +67,8 @@ class Skill extends Component {
   })
   .sort((a, b) => b.upvotes - a.upvotes);
 
-  initDialogState() {
-    this.state = {
+  getInitDialogState() {
+    return {
       resource_url: '',
       resource_description: '',
       resource_type: 'other',
@@ -118,7 +118,7 @@ class Skill extends Component {
         type: this.state.resource_type,
       });
       toggleOff(DIALOG_TOGGLE);
-      this.initDialogState();
+      this.setState(this.getInitDialogState());
     }
   }
 

--- a/app/components/Skill.jsx
+++ b/app/components/Skill.jsx
@@ -36,11 +36,7 @@ class Skill extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      resource_url: '',
-      resource_description: '',
-      resource_type: 'other',
-    };
+    this.initDialogState();
   }
 
   componentDidMount() {
@@ -70,6 +66,14 @@ class Skill extends Component {
     };
   })
   .sort((a, b) => b.upvotes - a.upvotes);
+
+  initDialogState() {
+    this.state = {
+      resource_url: '',
+      resource_description: '',
+      resource_type: 'other',
+    };
+  }
 
   /**
    * Handle TextField change.
@@ -114,6 +118,7 @@ class Skill extends Component {
         type: this.state.resource_type,
       });
       toggleOff(DIALOG_TOGGLE);
+      this.initDialogState();
     }
   }
 
@@ -141,14 +146,7 @@ class Skill extends Component {
       <FlatButton
         label="Add Resource"
         primary
-        onTouchTap={() => {
-          this.addResource(skillSlug);
-          this.setState({
-            resource_url: '',
-            resource_description: '',
-            resource_type: 'other',
-          });
-        }}
+        onTouchTap={() => this.addResource(skillSlug)}
       />,
     ];
 

--- a/app/components/Skill.jsx
+++ b/app/components/Skill.jsx
@@ -76,6 +76,7 @@ class Skill extends Component {
       resource_description: '',
       resource_type: 'other',
     };
+  }
 
   filterProfileIds(profile, ids) {
     return ids.indexOf(profile.id) > -1;


### PR DESCRIPTION
Corrected thanks to @szymonmichalak's suggestions in original PR (now closed): https://github.com/x-team/unleash/pull/388

PR sets state of Resource dialog in `onTouchTap` after adding the new resource:

````jsx
this.setState({
   resource_url: '',
   resource_description: '',
   resource_type: 'other',
});
````